### PR TITLE
Remove keepkey from the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -48,8 +48,6 @@
             {"vendorId": 9601,
              "productId": 6152},
             {"vendorId": 21324,
-             "productId": 1},
-            {"vendorId": 11044,
              "productId": 1}
         ]}
     ],

--- a/manifest_regtest.json
+++ b/manifest_regtest.json
@@ -48,8 +48,6 @@
             {"vendorId": 9601,
              "productId": 6152},
             {"vendorId": 21324,
-             "productId": 1},
-            {"vendorId": 11044,
              "productId": 1}
         ]}
     ],

--- a/manifest_testnet.json
+++ b/manifest_testnet.json
@@ -48,8 +48,6 @@
             {"vendorId": 9601,
              "productId": 6152},
             {"vendorId": 21324,
-             "productId": 1},
-            {"vendorId": 11044,
              "productId": 1}
         ]}
     ],


### PR DESCRIPTION
Since KeepKey isn't working and it appears that the supporting code was removed, can we remove it from the manifest? It potentially creates conflicts with the KeepKey chrome application.

Thanks.