### PR TITLE
Fix prepare.sh to correctly work on tags

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -3,8 +3,19 @@
 set -e
 
 WEBFILES_REPO="https://github.com/greenaddress/GreenAddressWebFiles.git"
-WEBFILES_BRANCH=$(git symbolic-ref HEAD)
-WEBFILES_BRANCH=${WEBFILES_BRANCH##refs/heads/}
+WEBFILES_BRANCH=$(git describe --exact-match --all)
+
+case "$WEBFILES_BRANCH" in
+heads/*)
+    WEBFILES_BRANCH=${WEBFILES_BRANCH#heads/}
+    ;;
+tags/*)
+    WEBFILES_BRANCH=crx-${WEBFILES_BRANCH#tags/}
+    ;;
+*)
+    WEBFILES_BRANCH=crx-$WEBFILES_BRANCH
+    ;;
+esac
 
 while [ $# -gt 0 ]; do
 key="$1"


### PR DESCRIPTION
BONUS: you don't need to change the WEBFILES_BRANCH variable before
every tag

Actually prepare.sh doesn't work on tags since git symbolic-ref HEAD fails and with set -e the script exists.