### PR TITLE
Use python2 -m virtualenv instead of virtualenv

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -84,7 +84,9 @@ if [ \! -e webfiles ]; then
 fi
 
 if [ \! -e venv ]; then
-    virtualenv venv
+    command -v python2 >/dev/null &&
+        python2 -m virtualenv venv ||
+        python -m virtualenv venv
 fi
 venv/bin/pip install -r webfiles/requirements.txt
 


### PR DESCRIPTION
On ArchLinux (for example) virtualenv is python3 virtualenv, so be sure
to use python2 virtualenv.